### PR TITLE
fix: guard Linux-only platform helpers

### DIFF
--- a/internal/chaos/cpu.go
+++ b/internal/chaos/cpu.go
@@ -11,14 +11,14 @@ import (
 	"runtime"
 	"sync"
 	"sync/atomic"
-
-	"golang.org/x/sys/unix"
 )
 
 // CPUScenario saturates the host CPU by running tight loops on multiple
 // goroutines. Pairs with the scheduler_contention rule (run-queue delay
 // climbs once N > NumCPU).
 type CPUScenario struct{}
+
+const wakerSleepNsec = 1_000_000
 
 func init() { Register(CPUScenario{}) }
 
@@ -81,18 +81,17 @@ func (s CPUScenario) Run(ctx context.Context, opts Options) error {
 		wg.Add(1)
 		go func(seed int64) {
 			defer wg.Done()
-			// Lock to a dedicated OS thread and sleep via the nanosleep
-			// syscall. time.Sleep parks the goroutine inside Go's
+			// Lock to a dedicated OS thread and sleep via nanosleep on
+			// Linux. time.Sleep parks the goroutine inside Go's
 			// runtime, which can resume it without going through the
 			// kernel scheduler — sched_wakeup never fires. Direct
 			// nanosleep guarantees the OS task transitions from
 			// TASK_INTERRUPTIBLE → TASK_RUNNING, which is what
 			// kerno's sched_delay collector measures.
 			runtime.LockOSThread()
-			r := rand.New(rand.NewSource(seed))          //nolint:gosec
-			ts := unix.Timespec{Sec: 0, Nsec: 1_000_000} // 1 ms
+			r := rand.New(rand.NewSource(seed)) //nolint:gosec
 			for ctx.Err() == nil {
-				_ = unix.Nanosleep(&ts, nil)
+				_ = chaosNanosleep(wakerSleepNsec)
 				var local float64
 				for k := 0; k < 5_000; k++ {
 					local += math.Sqrt(r.Float64())

--- a/internal/chaos/nanosleep_linux.go
+++ b/internal/chaos/nanosleep_linux.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package chaos
+
+import "golang.org/x/sys/unix"
+
+func chaosNanosleep(nsec int64) error {
+	ts := unix.Timespec{Sec: 0, Nsec: nsec}
+	return unix.Nanosleep(&ts, nil)
+}

--- a/internal/chaos/nanosleep_other.go
+++ b/internal/chaos/nanosleep_other.go
@@ -1,0 +1,13 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package chaos
+
+import "time"
+
+func chaosNanosleep(nsec int64) error {
+	time.Sleep(time.Duration(nsec))
+	return nil
+}

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -1,6 +1,8 @@
 // Copyright 2026 Optiqor contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build linux
+
 package cli
 
 import (

--- a/internal/cli/audit_unsafe.go
+++ b/internal/cli/audit_unsafe.go
@@ -1,6 +1,8 @@
 // Copyright 2026 Optiqor contributors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build linux
+
 package cli
 
 import "unsafe"

--- a/internal/cli/audit_unsupported.go
+++ b/internal/cli/audit_unsupported.go
@@ -1,0 +1,23 @@
+// Copyright 2026 Optiqor contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !linux
+
+package cli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+func newAuditCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "audit",
+		Short: "Audit security-sensitive kernel events",
+		Long:  "The audit command uses Linux inotify and is only supported on Linux.",
+		RunE: func(*cobra.Command, []string) error {
+			return errors.New("audit command is only supported on Linux")
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- move the CPU chaos scenario sleep call behind a platform helper
- keep Linux on `unix.Nanosleep` so scheduler wakeup behavior is preserved
- use `time.Sleep` on non-Linux platforms so the chaos package can compile and run targeted tests on macOS
- guard the Linux inotify-based audit implementation behind `linux` build tags
- add a non-Linux audit command stub that reports the unsupported platform instead of breaking compilation

## Validation

- `env GOCACHE=/private/tmp/kerno-go-build-cache go test ./internal/chaos -run 'TestScenarios/cpu|TestRunDispatchesScenario|TestRegistryHasAllScenarios|TestIntensity|TestPaired' -count=1`
- `env GOCACHE=/private/tmp/kerno-go-build-cache go test ./internal/chaos -run '^$'`
- `env GOCACHE=/private/tmp/kerno-go-build-cache GOOS=linux GOARCH=amd64 go test -c -o /private/tmp/kerno-chaos-linux.test ./internal/chaos`
- `env GOCACHE=/private/tmp/kerno-go-build-cache go test ./cmd/kerno -run '^$'`
- `env GOCACHE=/private/tmp/kerno-go-build-cache go test ./internal/cli -run 'Test.*Audit|TestRoot|TestCompletion|Test.*Flags' -count=1`
- `env GOCACHE=/private/tmp/kerno-go-build-cache GOOS=linux GOARCH=amd64 go test -c -o /private/tmp/kerno-linux.test ./cmd/kerno`
- `git diff --check`

The full `go test ./internal/chaos` package run is still blocked in this sandbox by the unrelated `tcp-churn` smoke test requiring a local TCP listener: `listen tcp 127.0.0.1:0: bind: operation not permitted`.
