### PR TITLE
fix(cli): hide completion command from top-level help (closes #39)

### DIFF
--- a/internal/cli/completion.go
+++ b/internal/cli/completion.go
@@ -9,8 +9,10 @@ import (
 
 func newCompletionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "completion [bash|zsh|fish|powershell]",
-		Short: "Generate shell completion scripts",
+		Use:                   "completion [bash|zsh|fish|powershell]",
+		Short:                 "Generate shell completion scripts",
+		Hidden:                true, // plumbing, not a feature (issue #39)
+		DisableFlagsInUseLine: true,
 		Long: `Generate shell completion scripts for kerno.
 
 Kerno uses spf13/cobra's built-in completion generation which supports
@@ -56,7 +58,6 @@ Alternatively, specify the shell with the first argument:
   $ kerno completion fish
   $ kerno completion powershell
 `,
-		DisableFlagsInUseLine: true,
 		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
 		Args:                  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## What

hides the `completion` command from top-level help. the command itself and all four shell generators are unchanged.

## Why

Fixes #39

pr #55 shipped the feature but missed the last acceptance criterion: "hidden from the top-level help by default". the command is plumbing, not a user-facing feature.

## How

single-line change: set `Hidden: true` on the cobra command. hidden commands stay fully functional and keep generating valid scripts. no new tests needed; existing `TestCompletionCmd` covers all four shells.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/cli/` passes (full `go test ./...` not run locally, no docker for integration tests)
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` passes
- [x] tested locally with: `/tmp/kerno --help | grep -i completion` (0 matches), `/tmp/kerno completion bash | bash -n`, `zsh -n`, `fish --no-execute`, and `__complete do` / `__complete doctor --output ''` return correct suggestions

- [x] N/A - pure docs/refactor

## Checklist

- [x] PR title follows Conventional Commits (`fix(cli): hide completion command from top-level help`)
- [x] All commits are DCO-signed (`git commit -s`)
- [x] No unrelated changes pulled in
- [x] Documentation updated where user-visible behavior changed (n/a — no user-visible behavior beyond help output; readme already documents the command)
- [x] Added/updated tests for new code paths (n/a — existing tests cover the command; hiding only affects help rendering)
- [x] If a new doctor rule, paired with a chaos scenario in `scripts/verify.sh` (n/a)